### PR TITLE
285 api version does not always show on first connection

### DIFF
--- a/Assets/Scenes/MirrorScene.unity
+++ b/Assets/Scenes/MirrorScene.unity
@@ -5124,6 +5124,98 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 674593025}
   m_CullTransparentMesh: 1
+--- !u!1 &712799953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 712799954}
+  - component: {fileID: 712799957}
+  - component: {fileID: 712799956}
+  - component: {fileID: 712799955}
+  m_Layer: 14
+  m_Name: VersionAPIText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &712799954
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712799953}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2008010110}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 151, y: -379}
+  m_SizeDelta: {x: 181.8, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &712799955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712799953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfb0d2cf8310ec54fa9f865bd2538842, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &712799956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712799953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 15
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'API version : <app_version>'
+--- !u!222 &712799957
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712799953}
+  m_CullTransparentMesh: 1
 --- !u!1 &719493069
 GameObject:
   m_ObjectHideFlags: 0
@@ -15179,6 +15271,7 @@ RectTransform:
   - {fileID: 2018509660}
   - {fileID: 1767778755}
   - {fileID: 2421365955669388730}
+  - {fileID: 712799954}
   m_Father: {fileID: 4575489516481370557}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}

--- a/Assets/Scripts/Robot/RobotAPICompatibilityCheck.cs
+++ b/Assets/Scripts/Robot/RobotAPICompatibilityCheck.cs
@@ -34,20 +34,23 @@ namespace TeleopReachy
 
         public void CheckCompatibility()
         {
-            string appApiVersion = ApplicationAPIVersion.Instance.GetApplicationAPIVersion();
-            string robotApiVersion = robotConfig.GetRobotAPIVersion();
-            switch (String.Compare(appApiVersion, robotApiVersion))
+            if (robotConfig.GotReachyConfig())
             {
-                case < 0:
-                    resolution_str = "Please download a newer teleoperation app.";
-                    needUpdate = true;
-                    break;
-                case 0:
-                    break;
-                case > 0:
-                    resolution_str = "Please update your robot core service (or download an older version of the teleoperation app).";
-                    needUpdate = true;
-                    break;
+                string appApiVersion = ApplicationAPIVersion.Instance.GetApplicationAPIVersion();
+                string robotApiVersion = robotConfig.GetRobotAPIVersion();
+                switch (String.Compare(appApiVersion, robotApiVersion))
+                {
+                    case < 0:
+                        resolution_str = "Please download a newer teleoperation app.";
+                        needUpdate = true;
+                        break;
+                    case 0:
+                        break;
+                    case > 0:
+                        resolution_str = "Please update your robot core service (or download an older version of the teleoperation app).";
+                        needUpdate = true;
+                        break;
+                }
             }
         }
     }

--- a/Assets/Scripts/Robot/RobotConfig.cs
+++ b/Assets/Scripts/Robot/RobotConfig.cs
@@ -105,7 +105,7 @@ namespace TeleopReachy
                     else 
                     {
                         var apiVersion = value.Descriptor.FindFieldByName("api_version");
-                        if (apiVersion !=null)
+                        if (apiVersion != null)
                         {
                             robot_api_version = (string)apiVersion.Accessor.GetValue(value);
                         }

--- a/Assets/Scripts/UI/TextAPIModifier.cs
+++ b/Assets/Scripts/UI/TextAPIModifier.cs
@@ -35,7 +35,9 @@ namespace TeleopReachy
         public void ChangeText(string stringToChange)
         {
             stringToChange = stringToChange.Replace(appVersion, ApplicationAPIVersion.Instance.GetApplicationAPIVersion());
-            newText = stringToChange.Replace(robotVersion, robotConfig.GetRobotAPIVersion());
+            bool api_filled = (robotConfig.GetRobotAPIVersion() != null) && (robotConfig.GetRobotAPIVersion() != "");
+            string robot_api = api_filled ? robotConfig.GetRobotAPIVersion() : "<1.0.16";
+            newText = stringToChange.Replace(robotVersion, robot_api);
             needUpdate = true;
         }
     }


### PR DESCRIPTION
The first config_changed event does not always contains the robot config.
We now check the config has been received. We also check if the api contains a relevant info, if the field is empty the API version id older than 1.0.16 (where we added the robot_api_version field)