### PR TITLE
Remove wild speed limit commands in ghost

### DIFF
--- a/Assets/Resources/GaelleGhostTeleoperationFiles/teleop_record_left_gripper.txt
+++ b/Assets/Resources/GaelleGhostTeleoperationFiles/teleop_record_left_gripper.txt
@@ -358,7 +358,6 @@
 [ { "handCommand": { "handGoal": { "id": { "id": 4, "name": "l_hand" }, "position": { "parallelGripper": { "openingPercentage": 1 } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 4, "name": "l_hand" }, "position": { "parallelGripper": { "openingPercentage": 1 } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 4, "name": "l_hand" }, "position": { "parallelGripper": { "openingPercentage": 1 } } } } } ]
-[ { "armCommand": { "speedLimit": { "id": { "id": 2, "name": "l_arm" }, "limit": 100 } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 4, "name": "l_hand" }, "position": { "parallelGripper": { "openingPercentage": 1 } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 4, "name": "l_hand" }, "position": { "parallelGripper": { "openingPercentage": 1 } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 4, "name": "l_hand" }, "position": { "parallelGripper": { "openingPercentage": 1 } } } } } ]

--- a/Assets/Resources/GaelleGhostTeleoperationFiles/teleop_record_right_gripper.txt
+++ b/Assets/Resources/GaelleGhostTeleoperationFiles/teleop_record_right_gripper.txt
@@ -357,7 +357,6 @@
 [ { "handCommand": { "handGoal": { "id": { "id": 5, "name": "r_hand" }, "position": { "parallelGripper": { } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 5, "name": "r_hand" }, "position": { "parallelGripper": { } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 5, "name": "r_hand" }, "position": { "parallelGripper": { } } } } } ]
-[ { "armCommand": { "speedLimit": { "id": { "id": 1, "name": "r_arm" }, "limit": 100 } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 5, "name": "r_hand" }, "position": { "parallelGripper": { } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 5, "name": "r_hand" }, "position": { "parallelGripper": { } } } } } ]
 [ { "handCommand": { "handGoal": { "id": { "id": 5, "name": "r_hand" }, "position": { "parallelGripper": { } } } } } ]


### PR DESCRIPTION
Remove the wild speed command limits that were sent through the lossy channel during teleoperation in ghost mode.